### PR TITLE
Node-style callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To see a working example, clone the repo and open [example/index.html](https://g
 
 |Code|Message|Resolution|
 |:--:|------|----------|
-|1|`Screenbot isn't running`|This error occurs when the library can't connect to the Screenbot desktop app. Make sure that you're initializing the client with a valid API token. You can manage your tokens on [your developer dashboard](https://app.screenbot.io/dashboard).|
+|1|`Screenbot isn't running`|This error occurs when the library can't connect to the Screenbot desktop app. Make sure that you're initializing the client with a valid API token. You can manage your tokens on [your developer dashboard](https://app.screenbot.io/dashboard).<br><br>Also, make sure the app is [running and connected](http://d.pr/i/BZHN). If have multiple accounts, check in the app under "Preferences" that Screenbot is signed in to the account that's [associated with your API token](http://d.pr/i/17UoA).|
 |2|`No data received`|This error occurs when there is no response from the Screenbot desktop app after a command is sent. Make sure your API tokens are valid. The app itself should display a more specific error as well.|
 
 ## License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Initialize the client
 var sb = new Screenbot("pk_test_sdk_token_value");
 ```
 
-You can manage your SDK keys on [your developer dashboard](https://app.screenbot.io/dashboard)
+You can manage your SDK keys on [your developer dashboard](https://app.screenbot.io/dashboard).
 
 Run a command:
 
@@ -32,7 +32,7 @@ sb.activate(function(err, result){
   // err has properties for the error's code and message
   if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
 
-  // result has a url property that points to screenshot.
+  // result has a url property that points to the uploaded drop
   console.log(result.url);
   // http://d.pr/i/zJSD
 });
@@ -42,7 +42,7 @@ sb.shot(function(err, result){
   // err has properties for the error's code and message
   if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
 
-  // result has a url property that points to screenshot. 
+  // result has a url property that points to a screenshot
   console.log(result.url);
   // http://d.pr/i/1kA2M
 });
@@ -52,7 +52,7 @@ sb.cast(function(err, result){
   // err has properties for the error's code and message
   if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
 
-  // result has a url property that points to an screencast.
+  // result has a url property that points to a screencast
   console.log(result.url);
   // http://d.pr/i/12A5W
 });
@@ -62,7 +62,7 @@ sb.clip(function(err, result){
   // err has properties for the error's code and message
   if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
 
-  // result has a url property that points to an annotated screenshot.
+  // result has a url property that points to the uploaded drop
   console.log(result.url);
   // http://d.pr/f/1iTCo
 });
@@ -70,6 +70,13 @@ sb.clip(function(err, result){
 ```
 
 To see a working example, clone the repo and open [example/index.html](https://github.com/Droplr/screenbot-js/blob/master/example/index.html) in your browser.
+
+## Error Codes
+
+|Code|Message|Resolution|
+|:--:|------|----------|
+|1|`Screenbot isn't running`|This error occurs when the library can't connect to the Screenbot desktop app. Make sure that you're initializing the client with a valid API token. You can manage your tokens on [your developer dashboard](https://app.screenbot.io/dashboard).|
+|2|`No data received`|This error occurs when there is no response from the Screenbot desktop app after a command is sent. Make sure your API tokens are valid. The app itself should display a more specific error as well.|
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,33 +21,55 @@ Initialize the client
 var sb = new Screenbot("pk_test_sdk_token_value");
 ```
 
-You can manage your SDK keys on [your developer dashboard](https://app.screenbot.io/developer)
+You can manage your SDK keys on [your developer dashboard](https://app.screenbot.io/dashboard)
 
 Run a command:
 
 ```javascript
 
 // Show the Screenbot menu for all connected clients
-sb.activate(function(success, result){
-  // result should be shortened link to screenshot. Example: http://d.pr/i/zJSD
+sb.activate(function(err, result){
+  // err has properties for the error's code and message
+  if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
+
+  // result has a url property that points to screenshot.
+  console.log(result.url);
+  // http://d.pr/i/zJSD
 });
 
 // Run the screenshot command for all connected clients. Same as /sb shot
-sb.shot(function(success, result){
-  // result should be shortened link to screenshot. Example: http://d.pr/i/1kA2M
+sb.shot(function(err, result){
+  // err has properties for the error's code and message
+  if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
+
+  // result has a url property that points to screenshot. 
+  console.log(result.url);
+  // http://d.pr/i/1kA2M
 });
 
 // Activate the screencast command for all connected clients. Same as /sb cast
-sb.cast(function(success, result){
-  // result should be shortened link to an screencast. Example: http://d.pr/i/12A5W
+sb.cast(function(err, result){
+  // err has properties for the error's code and message
+  if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
+
+  // result has a url property that points to an screencast.
+  console.log(result.url);
+  // http://d.pr/i/12A5W
 });
 
 // Upload whatever is in the client clipboard. Same as /sb clip
-sb.clip(function(success, result){
-  // result should be shortened link to an annotated screenshot. Example: http://d.pr/f/1iTCo
+sb.clip(function(err, result){
+  // err has properties for the error's code and message
+  if(err) return console.log('Error! Code: ' + err.code + ' Message: ' + err.message);
+
+  // result has a url property that points to an annotated screenshot.
+  console.log(result.url);
+  // http://d.pr/f/1iTCo
 });
 
 ```
+
+To see a working example, clone the repo and open [example/index.html](https://github.com/Droplr/screenbot-js/blob/master/example/index.html) in your browser.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ To see a working example, clone the repo and open [example/index.html](https://g
 
 |Code|Message|Resolution|
 |:--:|------|----------|
-|1|`Screenbot isn't running`|This error occurs when the library can't connect to the Screenbot desktop app. Make sure that you're initializing the client with a valid API token. You can manage your tokens on [your developer dashboard](https://app.screenbot.io/dashboard).<br><br>Also, make sure the app is [running and connected](http://d.pr/i/BZHN). If have multiple accounts, check in the app under "Preferences" that Screenbot is signed in to the account that's [associated with your API token](http://d.pr/i/17UoA).|
-|2|`No data received`|This error occurs when there is no response from the Screenbot desktop app after a command is sent. Make sure your API tokens are valid. The app itself should display a more specific error as well.|
+|1|`CLIENT_UNAVAILABLE`|This error occurs when the library can't connect to the Screenbot desktop app. Make sure that you're initializing the client with a valid API token. You can manage your tokens on [your developer dashboard](https://app.screenbot.io/dashboard).<br><br>Also, make sure the app is [running and connected](http://d.pr/i/BZHN). If have multiple accounts, check in the app under "Preferences" that Screenbot is signed in to the account that's [associated with your API token](http://d.pr/i/17UoA).|
+|2|`NO_DATA_RECEIVED`|This error occurs when there is no response from the Screenbot desktop app after a command is sent. Make sure your API tokens are valid. The app itself should display a more specific error as well.|
 
 ## License
 

--- a/example/index.html
+++ b/example/index.html
@@ -51,11 +51,11 @@
         $commandInput.val("");
         $commandInput.attr("disabled", true);
 
-        sb[command](function(error, response){
-          if(error) return $outputArea.append('Error ' + error.code + ': ' + error.message);
+        sb[command](function(err, result){
+          if(err) return $outputArea.append('Error! Code: ' + err.code + ' Message: ' + err.message);
 
-          $outputArea.append(drop_link + "\n");
-          $("#js-screenbot-command").removeAttr("disabled");
+          $outputArea.append(result.url + "\n");
+          $commandInput.removeAttr("disabled");
         });
       });
     });

--- a/example/index.html
+++ b/example/index.html
@@ -9,35 +9,52 @@
 <body>
   <div class="container">
     <h1>Screenbot</h1>
+
     <form method="post" id="js-token-form">
-    <input type="text" placeholder="Enter your Screenbot API key" id="js-token-value" style="width:200px; margin-right: 10px;"><input type="submit">
+      <input type="text" placeholder="Enter your Screenbot API key" id="js-token-value" style="width: 200px; margin-right: 10px;"><input type="submit">
     </form>
-    <form method="post" id="js-screenbot-form" style="display:none;">
-    <p style="margin: 10px 0; border: 2px solid #ccc; border-radius: 6px; padding: 0 10px;">
-     sb / <input type="text" style="width: 90%; border:0; outline: none; padding: 5px" id="js-screenbot-command" placeholder="[shot,draw,cast,clip,...]">
-    </p>
+
+    <form method="post" id="js-screenbot-form" style="display: none;">
+      <p style="margin: 10px 0; border: 2px solid #ccc; border-radius: 6px; padding: 0 10px;">sb /
+         <input type="text" style="width: 90%; border:0; outline: none; padding: 5px" id="js-screenbot-command" placeholder="[shot,draw,cast,clip,...]">
+      </p>
     </form>
+
     <br>
-    <textarea style="width: 100%; min-height: 100px" placeholder="Screenbot results will appear here"></textarea>
+
+    <textarea id="results" style="display: none; width: 100%; min-height: 100px" placeholder="Screenbot results will appear here"></textarea>
+
     <script>
     var sb;
 
     $(document).ready(function(){
       $("#js-token-form").submit(function(e){
         e.preventDefault();
-        sb = new Screenbot($("#js-token-value").val()/*, {host : "https://screenbot.herokuapp.com"}*/); // invoke
+
+        var token = $("#js-token-value").val();
+
+        if(!token.length) return alert("Please enter a Screenbot API key first");
+
+        sb = new Screenbot(token /*, {host : "https://screenbot.herokuapp.com"}*/); // invoke
+
         $("#js-screenbot-form").show();
+        $("#results").show();
       });
 
       $("#js-screenbot-form").submit(function(e){
         e.preventDefault();
-        if(!sb) return alert("Please enter a Screenbot API key first");
 
-        var command = $("#js-screenbot-command").val();
-        $("#js-screenbot-command").val("");
-        $("#js-screenbot-command").attr("disabled", true);
-        sb.activate(function(success, drop_link){
-          $("textarea").append(drop_link + "\n");
+        var $commandInput = $("#js-screenbot-command"),
+            command       = $commandInput.val(),
+            $outputArea   = $("#results");
+
+        $commandInput.val("");
+        $commandInput.attr("disabled", true);
+
+        sb[command](function(error, response){
+          if(error) return $outputArea.append('Error ' + error.code + ': ' + error.message);
+
+          $outputArea.append(drop_link + "\n");
           $("#js-screenbot-command").removeAttr("disabled");
         });
       });

--- a/src/screenbot.js
+++ b/src/screenbot.js
@@ -38,6 +38,13 @@ var Screenbot = (function Screenbot() {
       xhttp.send();
     };
 
+    var _handleError = function(response, cb){
+      var error = new Error(response.error);
+      error.code = 1;
+
+      return cb(error);
+    };
+
     // Return the constructor
     return function ScreenbotConstructor(token, args) {
         var _this = this; // Cache the `this` keyword
@@ -51,11 +58,12 @@ var Screenbot = (function Screenbot() {
 
           _request(_endpoint(command), function(success, response) {
 
-            if (!success) return cb(false, response.error);
+            if (!success || !response.ok) return _handleError(response, cb);
 
             if(_private.source && _private.source.readyState !== 2) {
               _private.source.close();
             }
+
             _private.source = new EventSource(_response_endpoint(response.token));
             _private.source.onmessage = function(event) {
               _private.source.close();

--- a/src/screenbot.js
+++ b/src/screenbot.js
@@ -1,3 +1,8 @@
+var ERROR_CODES = {
+  CLIENT_UNAVAILABLE: 1,
+  NO_DATA_RECEIVED: 2
+};
+
 var Screenbot = (function Screenbot() {
     var _private = {
         "source"  : null, // Our EventSource connection
@@ -67,7 +72,7 @@ var Screenbot = (function Screenbot() {
           console.log("Source: " + _private.source);
 
           _request(_endpoint(command), function(err, result) {
-            if(err) return _handleError({ code: 1, message: result.error }, cb);
+            if(err) return _handleError({ code: ERROR_CODES.CLIENT_UNAVAILABLE, message: err.error }, cb);
             if('connected' in result) return cb(null, { connected: result.connected });
 
             if(_private.source && _private.source.readyState !== 2) {
@@ -77,7 +82,7 @@ var Screenbot = (function Screenbot() {
             _private.source = new EventSource(_response_endpoint(result.token));
             _private.source.onmessage = function(event) {
               _private.source.close();
-              if(event.data === "0" || !event.data.length) return _handleError({ code: 2, message: 'No data received' }, cb);
+              if(event.data === "0" || !event.data.length) return _handleError({ code: ERROR_CODES.NO_DATA_RECEIVED, message: 'No data received' }, cb);
 
               var eventData = { url: event.data };
               cb(null, eventData);

--- a/src/screenbot.js
+++ b/src/screenbot.js
@@ -24,14 +24,16 @@ var Screenbot = (function Screenbot() {
              channel_token;
     };
 
-    var _request = function(endpoint, callback){
+    var _request = function(endpoint, cb){
       var xhttp = new XMLHttpRequest();
       xhttp.onreadystatechange = function() {
         if (xhttp.readyState === 4 && xhttp.status === 200) {
           var response = JSON.parse(xhttp.responseText);
-          callback(response.ok, response);
+          if(!response.ok) return cb(response);
+          cb(null, response);
         } else if(xhttp.readyState === 4) {
-          callback(false, xhttp.responseText);
+          var response = JSON.parse(xhttp.responseText);
+          cb(response);
         }
       };
       xhttp.open("GET", endpoint, true);
@@ -64,20 +66,21 @@ var Screenbot = (function Screenbot() {
         _this.command = function (command, cb) {
           console.log("Source: " + _private.source);
 
-          _request(_endpoint(command), function(success, response) {
-            if (!success || !response.ok) return _handleError({ code: 1, message: response.error }, cb);
+          _request(_endpoint(command), function(err, result) {
+            if(err) return _handleError({ code: 1, message: result.error }, cb);
+            if('connected' in result) return cb(null, { connected: result.connected });
 
             if(_private.source && _private.source.readyState !== 2) {
               _private.source.close();
             }
 
-            _private.source = new EventSource(_response_endpoint(response.token));
+            _private.source = new EventSource(_response_endpoint(result.token));
             _private.source.onmessage = function(event) {
               _private.source.close();
               if(event.data === "0" || !event.data.length) return _handleError({ code: 2, message: 'No data received' }, cb);
 
-              var result = { url: event.data };
-              cb(null, result);
+              var eventData = { url: event.data };
+              cb(null, eventData);
             };
           });
         };

--- a/src/screenbot.js
+++ b/src/screenbot.js
@@ -51,10 +51,10 @@ var Screenbot = (function Screenbot() {
     };
 
     var ScreenbotError = function(code, message){
+      Error.call(this);
       this.name = 'Screenbot Error';
       this.code = code;
       this.message = message || findErrorMessage(code) || 'An error has occurred';
-      this.stack = (new Error()).stack;
 
       function findErrorMessage(code) {
         for (var error in ERROR_CODES) {


### PR DESCRIPTION
This implements Node-style callbacks referenced in issue #1 . The library now returns an instance of `Error`, when applicable, with `code` and `message` property as the first parameter. The error codes are very simple at this point and are [explained in the README](https://github.com/Droplr/screenbot-js/blob/886084ce8c935cc45f16e143d8a84d993cd4b543/README.md#error-codes).

If no error occurs, `err` is `null` and `result` is an object with a `url` parameter that points to the uploaded drop.
